### PR TITLE
patch book endpoint to update availability of book

### DIFF
--- a/routers/book.js
+++ b/routers/book.js
@@ -144,4 +144,14 @@ router.get("/:id", async (req, res) => {
   }
 });
 
+router.patch("/:id", async (req, res) => {
+  const book = await Book.findByPk(req.params.id);
+
+  const isAvailable = false;
+
+  await book.update({ isAvailable });
+
+  return res.send({ book });
+});
+
 module.exports = router;


### PR DESCRIPTION
update book endpoint is created to be able to update the availability of the book, it is called with the post borrow item request in the front end. 